### PR TITLE
Also throw error when mutatienummer is 0

### DIFF
--- a/eboekhouden_python/eboekhouden_client.py
+++ b/eboekhouden_python/eboekhouden_client.py
@@ -126,7 +126,7 @@ class EboekhoudenClient:
 
         self._check_response(response)
 
-        if response["Mutatienummer"] is None:
+        if response["Mutatienummer"] is None or response["Mutatienummer"] == 0:
             raise ValueError("Error adding mutatie")
 
         return response["Mutatienummer"]


### PR DESCRIPTION
Hi! Thanks for the nice library!

When using it I encountered a bug, if you add a mutatie with a description of more than 200 chars, the api returns a mutatie number of 0, which is invalid, and it does not create a mutatie in eboekhouden. However this library does not throw an error, which caused me a few hours of debugging time.

This 200 char limit is also stated in the api documentation: https://cdn.e-boekhouden.nl/handleiding/Documentation_soap_english.pdf

Maybe some validator might be nice, but for now I think this would be a nice improvement.

Thanks again!