### PR TITLE
fix SOAP field used for indicating ledenadministratie 

### DIFF
--- a/eboekhouden_python/models/relatie.py
+++ b/eboekhouden_python/models/relatie.py
@@ -98,7 +98,7 @@ class Relatie:
             def8=serialized_relation.get("Def8"),
             def9=serialized_relation.get("Def9"),
             def10=serialized_relation.get("Def10"),
-            leden_administratie=serialized_relation.get("LedenAdministratie"),
+            leden_administratie=serialized_relation.get("LA"),
             geen_email=serialized_relation.get("GeenEmail"),
             gb_id=serialized_relation.get("GBID"),
             nieuwsbrief_groepen_count=serialized_relation.get("NieuwsbriefGroepenCount"),
@@ -150,7 +150,7 @@ class Relatie:
                 Def8=self.def8 or ZeepXsdSkipValue,
                 Def9=self.def9 or ZeepXsdSkipValue,
                 Def10=self.def10 or ZeepXsdSkipValue,
-                LedenAdministratie=self.leden_administratie or ZeepXsdSkipValue,
+                LA=self.leden_administratie or ZeepXsdSkipValue,
             )
         return export_dict
 

--- a/tests/test_models_relatie.py
+++ b/tests/test_models_relatie.py
@@ -110,7 +110,7 @@ def test_relatie_partially_filled_additional_fields():
         Def8="1",
         Def9="1",
         Def10="1",
-        LedenAdministratie="1",
+        LA="1",
     )
 
 


### PR DESCRIPTION
In correspondence with e-boekhouden Handleiding Soap versie 5.7
the Relatie field for 'ledenadministratie' is labeled 'LA'  (see page 10).

Fixes #2 