### PR TITLE
allow to specify add_relatie should also send the additional fields

### DIFF
--- a/eboekhouden_python/eboekhouden_client.py
+++ b/eboekhouden_python/eboekhouden_client.py
@@ -160,14 +160,14 @@ class EboekhoudenClient:
         relatie_objects = [Relatie.from_zeep(x) for x in relaties["Relaties"]["cRelatie"]]
         return relatie_objects
 
-    def add_relatie(self, relatie: Relatie) -> str:
+    def add_relatie(self, relatie: Relatie, additional_fields: bool = False) -> str:
         """Add mutatie."""
         self.get_session_id()
 
         response = self._client.service.AddRelatie(
             SessionID=self._session_id,
             SecurityCode2=self._code2,
-            oRel=relatie.export(),
+            oRel=relatie.export(additional_fields),
         )
 
         self._check_response(response)


### PR DESCRIPTION
Added parameter to add_relatie to indicate the additional fields need to be sent as well.
See issue #3.